### PR TITLE
Reduce load-time invalidations from untyped operator methods

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -731,8 +731,10 @@ function ∘(m2::$t, m1::$t)
   return m
 end
 
-# When composing a TPS scalar/vector function w a map, use orbital part of map:
-function ∘(m2, m1::$t)
+# When composing a TPS scalar/vector function w a map, use orbital part of map.
+# `m2` is constrained to Number/AbstractArray (a TPS scalar or vector function) so
+# that inserting this method does not invalidate compiled `∘(::Any, ...)` callers.
+function ∘(m2::Union{Number,AbstractArray}, m1::$t)
   TI.is_tps_type(eltype(m2)) isa TI.IsTPSType || error("Cannot compose: $(eltype(m2)) is not a TPS type supported by TPSAInterface.jl")
   T = promote_type(eltype(m1.v), eltype(m2))
   T == eltype(m1.v) ? m1xprom = m1.v : m1xprom = T.(m1.v)
@@ -751,8 +753,11 @@ literal_pow(::typeof(^), m::$t{V0,V,Q,S}, vn::Val{-1}) where {V0,V,Q,S} = inv(m)
 inv(m::$t; do_spin::Bool=true) = (out_m = zero(m); inv!(out_m, m, do_spin=do_spin); return out_m)
 ^(m::$t, n::Integer) = (out_m = zero(m); pow!(out_m, m, n); return out_m)
 
-# Also allow * for simplicity and \ and / 
-*(m2, m1::$t) = ∘(m2, m1)
+# Also allow * for simplicity and \ and /
+# Split the former untyped `*(m2, m1::$t)` into concrete-argument methods so that
+# inserting them does not invalidate compiled `*(::Any, ...)` callers.
+*(m2::$t, m1::$t) = ∘(m2, m1)
+*(m2::Union{Number,AbstractArray}, m1::$t) = ∘(m2, m1)
 /(m2::$t, m1::$t) = m2 ∘ inv(m1) 
 \(m2::$t, m1::$t) = inv(m2) ∘ m1
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -475,8 +475,8 @@ const S = SymplecticS()
 
 for op = (:+, :-, :*, :/)
 @eval begin
-Base.$op(S::SymplecticS,M) = Base.$op(JMatrix{Int8,+1}(size(M,1)), M)
-Base.$op(M,S::SymplecticS) = Base.$op(M, JMatrix{Int8,+1}(size(M,2)))
+Base.$op(S::SymplecticS,M::AbstractVecOrMat) = Base.$op(JMatrix{Int8,+1}(size(M,1)), M)
+Base.$op(M::AbstractVecOrMat,S::SymplecticS) = Base.$op(M, JMatrix{Int8,+1}(size(M,2)))
 end
 end
 


### PR DESCRIPTION
## Reduce load-time invalidations from untyped operator methods

Part of the invalidation-reduction work tracked in bmad-sim/SciBmad.jl#77.

### Problem
Several operators were defined with an **untyped** first (or second) argument, which makes them `f(::Any, …)` methods. Inserting such methods at package load time invalidates large amounts of already-compiled generic code that calls the same functions:

- `map.jl`: `*(m2, m1::$t) = ∘(m2, m1)` → `*(::Any, ::DAMap)` / `*(::Any, ::TPSAMap)`
- `map.jl`: `∘(m2, m1::$t)` → `∘(::Any, ::DAMap)` / `∘(::Any, ::TPSAMap)`
- `utils.jl`: the `SymplecticS` `+ - * /` operators → `*(::Any, ::SymplecticS)`, `*(::SymplecticS, ::Any)`, etc.

### Fix
Constrain the arguments to the types actually accepted (no behavior change for valid inputs):

- `*(m2, m1::TaylorMap)` is split into
  - `*(m2::$t, m1::$t)` — map ∘ map composition, and
  - `*(m2::Union{Number,AbstractArray}, m1::$t)` — TPS scalar/vector-function composition.
- `∘(m2, m1::$t)` gains the same `m2::Union{Number,AbstractArray}` constraint (its body already requires `eltype(m2)` to be a TPS type).
- The `SymplecticS` operators constrain the matrix argument to `AbstractVecOrMat` (they already index it with `size(M, …)`).

`DAMap`/`TPSAMap` are `<: TaylorMap` (not `<: Number`/`AbstractArray`), so the split methods are unambiguous.

### Measurement
Using `SnoopCompile`'s `@snoop_invalidations using SciBmad` (Julia 1.11.7):

| | NonlinearNormalForm invalidation children |
|---|---:|
| before | 197 |
| after | **56** |

The 141 removed are exactly the untyped `*` and `SymplecticS` roots (`*(m2, m1::DAMap)` = 41, `*(m2, m1::TPSAMap)` = 41, `*(M, S::SymplecticS)` = 41, `*(S::SymplecticS, M)` = 16, `+(M, S::SymplecticS)` = 2). No new roots are introduced. The residual 56 are the concrete-argument `∘` map-composition methods, which are structural.

### Tests
`Pkg.test("NonlinearNormalForm")` passes, including the "Composition and inversion" (14/14) and "Comparison with FPP" (19/19) suites that directly exercise the changed operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
